### PR TITLE
RABSW-1025: Check for kubernetes python module

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -287,6 +287,7 @@ fi
 dnl Ensure PYTHON is an absolute path
 AC_PATH_PROG([PYTHON], [$PYTHON])
 
+AC_PYTHON_MODULE(kubernetes, 1)
 AC_PYTHON_MODULE(pexpect, 1)
 AC_PYTHON_MODULE(pycurl, 1)
 AC_PYTHON_MODULE(requests, 1)


### PR DESCRIPTION
The NNF fencing agent needs the kubernetes python module. Add the check to the configure.ac file.